### PR TITLE
ユーザー名取得に関するエンハンスメント

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Keita Moromizato <keita_moromizato@relationsgroup.co.jp>",
   "description": "A simple helpful robot for your Company",
   "dependencies": {
+    "bluebird": "^2.7.1",
     "hubot": "^2.10.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-google-images": "^0.1.2",
@@ -19,6 +20,8 @@
     "hubot-shipit": "^0.1.1",
     "hubot-slack": "^3.2.1",
     "hubot-youtube": "^0.1.2",
+    "moment": "^2.9.0",
+    "moment-timezone": "^0.3.0",
     "qiita": "^1.2.0",
     "slack-node": "0.0.93"
   },


### PR DESCRIPTION
#### 変更点

* slackのユーザーIDからnameをusers.info APIにて取得し表示する
* デザインを表形式にし見た目を整える

見た目はこんな感じです。
https://relationslab.qiita.com/shared/items/d8e2e71c3b35c02c7777

#### 備考

* Slack APIのusers.infoを使ってるんですが、同期的に情報を取得する必要がありPromise(bluebird)をインストールしています。初めて使ったPromiseとなれないCoffeeScriptのダブルパンチでめちゃくちゃ時間がかかってしまいました。。。
* 時刻処理のためにmomentをインストールしています（使ってるのはmoment-timezoneなので、momentのほうはpackage.jsonから消しても良いかも）
* ただし、tsで取得されるSlackのタイムスタンプは精度がかなり怪しくてまずUTCで入ってないし、そもそも20分ほどズレがあるように思います。なので時刻は出してますが参考程度にしかならないかも
